### PR TITLE
PersistKeysToServiceFabric ServiceUri SDK Upgrade

### DIFF
--- a/AspNetCore.DataProtection.ServiceFabric.Common/AspNetCore.DataProtection.ServiceFabric.Common.csproj
+++ b/AspNetCore.DataProtection.ServiceFabric.Common/AspNetCore.DataProtection.ServiceFabric.Common.csproj
@@ -18,7 +18,7 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <Version>1.0.4</Version>
     <Authors>Medic Consulting</Authors>
-    <PackageReleaseNotes>Initial release set to 1.0.3 as this library is meant to be used with AspNetCore.DataProtection.ServiceFabric version 1.0.3</PackageReleaseNotes>
+    <PackageReleaseNotes>Release set to 1.0.4 as this library is meant to be used with AspNetCore.DataProtection.ServiceFabric version 1.0.4</PackageReleaseNotes>
     <PackageTags>ServiceFabric Service Fabric .Net Core Data Protection SFNuGet</PackageTags>
     <PackageIconUrl>https://nuget.org/Content/Images/packageDefaultIcon-50x50.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/MedAnd/AspNetCore.DataProtection.ServiceFabric</PackageProjectUrl>

--- a/AspNetCore.DataProtection.ServiceFabric.Common/AspNetCore.DataProtection.ServiceFabric.Common.csproj
+++ b/AspNetCore.DataProtection.ServiceFabric.Common/AspNetCore.DataProtection.ServiceFabric.Common.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <Description>Learn more about this project at www.medic-consulting.com</Description>
@@ -16,7 +16,7 @@
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
     <GenerateAssemblyRepositoryUrl>false</GenerateAssemblyRepositoryUrl>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
-    <Version>1.0.3</Version>
+    <Version>1.0.4</Version>
     <Authors>Medic Consulting</Authors>
     <PackageReleaseNotes>Initial release set to 1.0.3 as this library is meant to be used with AspNetCore.DataProtection.ServiceFabric version 1.0.3</PackageReleaseNotes>
     <PackageTags>ServiceFabric Service Fabric .Net Core Data Protection SFNuGet</PackageTags>
@@ -28,8 +28,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="1.1.3" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="1.1.1" />
-    <PackageReference Include="Microsoft.ServiceFabric.Services" Version="2.8.219" />
-    <PackageReference Include="Microsoft.ServiceFabric.Services.Remoting" Version="2.8.219" />
+    <PackageReference Include="Microsoft.ServiceFabric.Services" Version="3.1.283" />
+    <PackageReference Include="Microsoft.ServiceFabric.Services.Remoting" Version="3.1.283" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">

--- a/AspNetCore.DataProtection.ServiceFabric.Common/Extensions/DataProtectionBuilderExtensions.cs
+++ b/AspNetCore.DataProtection.ServiceFabric.Common/Extensions/DataProtectionBuilderExtensions.cs
@@ -8,14 +8,19 @@ namespace AspNetCore.DataProtection.ServiceFabric.Extensions
 {
     public static class DataProtectionBuilderExtensions
     {
-        public static IDataProtectionBuilder PersistKeysToServiceFabric(this IDataProtectionBuilder builder)
+        public static IDataProtectionBuilder PersistKeysToServiceFabric(this IDataProtectionBuilder builder, string serviceUri)
         {
             if (builder == null)
             {
                 throw new ArgumentNullException(nameof(builder));
             }
 
-            return builder.Use(ServiceDescriptor.Singleton<IXmlRepository>(services => new ServiceFabricXmlRepository()));
+            if (string.IsNullOrEmpty(serviceUri))
+            {
+                throw new ArgumentNullException(nameof(serviceUri));
+            }
+
+            return builder.Use(ServiceDescriptor.Singleton<IXmlRepository>(services => new ServiceFabricXmlRepository(serviceUri)));
         }
 
         public static IDataProtectionBuilder Use(this IDataProtectionBuilder builder, ServiceDescriptor descriptor)

--- a/AspNetCore.DataProtection.ServiceFabric.Common/Interfaces/IDataProtectionService.cs
+++ b/AspNetCore.DataProtection.ServiceFabric.Common/Interfaces/IDataProtectionService.cs
@@ -4,7 +4,7 @@ using System.Xml.Linq;
 using Microsoft.ServiceFabric.Services.Remoting;
 using Microsoft.ServiceFabric.Services.Remoting.FabricTransport;
 
-[assembly: FabricTransportServiceRemotingProvider(RemotingListener = RemotingListener.CompatListener, RemotingClient = RemotingClient.V2Client)]
+[assembly: FabricTransportServiceRemotingProvider(RemotingListener = RemotingListener.V2Listener, RemotingClient = RemotingClient.V2Client)]
 
 namespace AspNetCore.DataProtection.ServiceFabric.Interfaces
 {

--- a/AspNetCore.DataProtection.ServiceFabric.Common/Repositories/ServiceFabricXmlRepository.cs
+++ b/AspNetCore.DataProtection.ServiceFabric.Common/Repositories/ServiceFabricXmlRepository.cs
@@ -4,16 +4,25 @@ using Microsoft.ServiceFabric.Services.Client;
 using Microsoft.ServiceFabric.Services.Remoting.Client;
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using System.Xml.Linq;
 
 namespace AspNetCore.DataProtection.ServiceFabric.Repositories
 {
     public class ServiceFabricXmlRepository : IXmlRepository
     {
+        private readonly string _serviceUri;
+
+        public ServiceFabricXmlRepository(string serviceUri)
+        {
+            _serviceUri = serviceUri;
+        }
+
         public IReadOnlyCollection<XElement> GetAllElements()
         {
-            var proxy = ServiceProxy.Create<IDataProtectionService>(new Uri("fabric:/ServiceFabric.DataProtection/DataProtectionService"), new ServicePartitionKey());
-            return proxy.GetAllDataProtectionElements().Result.AsReadOnly();
+            var proxy = ServiceProxy.Create<IDataProtectionService>(new Uri(_serviceUri), new ServicePartitionKey());
+            var elements = Task.Run(() => proxy.GetAllDataProtectionElements()).GetAwaiter().GetResult();
+            return elements.AsReadOnly();
         }
 
         public void StoreElement(XElement element, string friendlyName)
@@ -23,8 +32,8 @@ namespace AspNetCore.DataProtection.ServiceFabric.Repositories
                 throw new ArgumentNullException(nameof(element));
             }
 
-            var proxy = ServiceProxy.Create<IDataProtectionService>(new Uri("fabric:/ServiceFabric.DataProtection/DataProtectionService"), new ServicePartitionKey());
-            proxy.AddDataProtectionElement(element).Wait();
+            var proxy = ServiceProxy.Create<IDataProtectionService>(new Uri(_serviceUri), new ServicePartitionKey());
+            Task.Run(() => proxy.AddDataProtectionElement(element)).GetAwaiter().GetResult();
         }
     }
 }

--- a/AspNetCore.DataProtection.ServiceFabric/AspNetCore.DataProtection.ServiceFabric.csproj
+++ b/AspNetCore.DataProtection.ServiceFabric/AspNetCore.DataProtection.ServiceFabric.csproj
@@ -17,7 +17,7 @@
     <GenerateAssemblyRepositoryUrl>false</GenerateAssemblyRepositoryUrl>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <IsServiceFabricServiceProject>True</IsServiceFabricServiceProject>
-    <Version>1.0.3</Version>
+    <Version>1.0.4</Version>
     <Authors>Medic Consulting</Authors>
     <PackageProjectUrl>https://github.com/MedAnd/AspNetCore.DataProtection.ServiceFabric</PackageProjectUrl>
     <PackageIconUrl>https://nuget.org/Content/Images/packageDefaultIcon-50x50.png</PackageIconUrl>
@@ -35,9 +35,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.ServiceFabric" Version="6.0.219" />
-    <PackageReference Include="Microsoft.ServiceFabric.Services" Version="2.8.219" />
-    <PackageReference Include="Microsoft.ServiceFabric.Services.Remoting" Version="2.8.219" />
+    <PackageReference Include="Microsoft.ServiceFabric" Version="6.2.283" />
+    <PackageReference Include="Microsoft.ServiceFabric.Services" Version="3.1.283" />
+    <PackageReference Include="Microsoft.ServiceFabric.Services.Remoting" Version="3.1.283" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">

--- a/AspNetCore.DataProtection.ServiceFabric/PackageRoot/ServiceManifest.xml
+++ b/AspNetCore.DataProtection.ServiceFabric/PackageRoot/ServiceManifest.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <ServiceManifest Name="AspNetCore.DataProtection.ServiceFabricPkg"
-                 Version="1.0.3"
+                 Version="1.0.4"
                  xmlns="http://schemas.microsoft.com/2011/01/fabric"
                  xmlns:xsd="http://www.w3.org/2001/XMLSchema"
                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
@@ -11,7 +11,7 @@
   </ServiceTypes>
 
   <!-- Code package is your service executable. -->
-  <CodePackage Name="Code" Version="1.0.3">
+  <CodePackage Name="Code" Version="1.0.4">
     <EntryPoint>
       <ExeHost>
         <Program>AspNetCore.DataProtection.ServiceFabric.exe</Program>
@@ -21,7 +21,7 @@
 
   <!-- Config package is the contents of the Config directoy under PackageRoot that contains an 
        independently-updateable and versioned set of custom configuration settings for your service. -->
-  <ConfigPackage Name="Config" Version="1.0.3" />
+  <ConfigPackage Name="Config" Version="1.0.4" />
 
   <Resources>
     <Endpoints>

--- a/ServiceFabric.DataProtection.Web/ServiceFabric.DataProtection.Web.csproj
+++ b/ServiceFabric.DataProtection.Web/ServiceFabric.DataProtection.Web.csproj
@@ -27,7 +27,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Routing" Version="1.1.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Server.WebListener" Version="1.1.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Server.WebListener" Version="1.1.4" />
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="1.1.3" />
     <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="1.1.3" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="1.1.2" />
@@ -38,10 +38,10 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="1.1.4" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.1.2" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="1.1.2" />
-    <PackageReference Include="Microsoft.ServiceFabric.AspNetCore.Kestrel" Version="2.8.219" />
-    <PackageReference Include="Microsoft.ServiceFabric.AspNetCore.WebListener" Version="2.8.219" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="1.0.0" />
-    <PackageReference Include="CommandLineParser" Version="2.1.1-beta" />
+    <PackageReference Include="Microsoft.ServiceFabric.AspNetCore.Kestrel" Version="3.1.283" />
+    <PackageReference Include="Microsoft.ServiceFabric.AspNetCore.WebListener" Version="3.1.283" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="2.4.0" />
+    <PackageReference Include="CommandLineParser" Version="2.2.1" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">

--- a/ServiceFabric.DataProtection.Web/Startup.cs
+++ b/ServiceFabric.DataProtection.Web/Startup.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Swashbuckle.AspNetCore.Swagger;
+using System.Fabric;
 
 namespace ServiceFabric.DataProtection.Web
 {
@@ -29,10 +30,20 @@ namespace ServiceFabric.DataProtection.Web
             // Add framework services.
             services.AddMvc();
 
+            string dataProtectionServiceUri = string.Empty;
+            try
+            {
+                dataProtectionServiceUri = $"{FabricRuntime.GetActivationContext().ApplicationName}/DataProtectionService";
+            }
+            catch
+            {
+                dataProtectionServiceUri = "fabric:/ServiceFabric.DataProtection/DataProtectionService";
+            }
+
             // Add Service Fabric DataProtection
             services.AddDataProtection()
                     .SetApplicationName("ServiceFabric-DataProtection-Web")
-                    .PersistKeysToServiceFabric();
+                    .PersistKeysToServiceFabric(dataProtectionServiceUri);
 
             services.AddSwaggerGen(c =>
             {

--- a/ServiceFabric.DataProtection.sln
+++ b/ServiceFabric.DataProtection.sln
@@ -9,7 +9,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ServiceFabric.DataProtectio
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AspNetCore.DataProtection.ServiceFabric", "AspNetCore.DataProtection.ServiceFabric\AspNetCore.DataProtection.ServiceFabric.csproj", "{7FBABD19-5B5A-47E7-8E20-C62A9751B354}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AspNetCore.DataProtection.ServiceFabric.Common", "AspNetCore.DataProtection.ServiceFabric.Common\AspNetCore.DataProtection.ServiceFabric.Common.csproj", "{BCA77547-9671-4EC9-BDA6-C6C1F7B41CC6}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AspNetCore.DataProtection.ServiceFabric.Common", "AspNetCore.DataProtection.ServiceFabric.Common\AspNetCore.DataProtection.ServiceFabric.Common.csproj", "{BCA77547-9671-4EC9-BDA6-C6C1F7B41CC6}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -20,6 +20,7 @@ Global
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{A412C9FE-DD03-40D8-80F7-F9806A083140}.Debug|Any CPU.ActiveCfg = Debug|x64
+		{A412C9FE-DD03-40D8-80F7-F9806A083140}.Debug|Any CPU.Deploy.0 = Debug|x64
 		{A412C9FE-DD03-40D8-80F7-F9806A083140}.Debug|x64.ActiveCfg = Debug|x64
 		{A412C9FE-DD03-40D8-80F7-F9806A083140}.Debug|x64.Build.0 = Debug|x64
 		{A412C9FE-DD03-40D8-80F7-F9806A083140}.Debug|x64.Deploy.0 = Debug|x64

--- a/ServiceFabric.DataProtection/ApplicationPackageRoot/ApplicationManifest.xml
+++ b/ServiceFabric.DataProtection/ApplicationPackageRoot/ApplicationManifest.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<ApplicationManifest xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ApplicationTypeName="ServiceFabric.DataProtectionType" ApplicationTypeVersion="1.0.3" xmlns="http://schemas.microsoft.com/2011/01/fabric">
+<ApplicationManifest xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ApplicationTypeName="ServiceFabric.DataProtectionType" ApplicationTypeVersion="1.0.4" xmlns="http://schemas.microsoft.com/2011/01/fabric">
   <Parameters>
     <Parameter Name="DataProtectionService_MinReplicaSetSize" DefaultValue="2" />
     <Parameter Name="DataProtectionService_TargetReplicaSetSize" DefaultValue="3" />
@@ -11,7 +11,7 @@
        should match the Name and Version attributes of the ServiceManifest element defined in the 
        ServiceManifest.xml file. -->
   <ServiceManifestImport>
-    <ServiceManifestRef ServiceManifestName="AspNetCore.DataProtection.ServiceFabricPkg" ServiceManifestVersion="1.0.3" />
+    <ServiceManifestRef ServiceManifestName="AspNetCore.DataProtection.ServiceFabricPkg" ServiceManifestVersion="1.0.4" />
     <ConfigOverrides />
   </ServiceManifestImport>
   <ServiceManifestImport>

--- a/ServiceFabric.DataProtection/ServiceFabric.DataProtection.sfproj
+++ b/ServiceFabric.DataProtection/ServiceFabric.DataProtection.sfproj
@@ -1,10 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" InitialTargets=";ValidateMSBuildFiles">
-  <Import Project="..\packages\Microsoft.VisualStudio.Azure.Fabric.MSBuild.1.6.3\build\Microsoft.VisualStudio.Azure.Fabric.Application.props" Condition="Exists('..\packages\Microsoft.VisualStudio.Azure.Fabric.MSBuild.1.6.3\build\Microsoft.VisualStudio.Azure.Fabric.Application.props')" />
+  <Import Project="..\packages\Microsoft.VisualStudio.Azure.Fabric.MSBuild.1.6.6\build\Microsoft.VisualStudio.Azure.Fabric.Application.props" Condition="Exists('..\packages\Microsoft.VisualStudio.Azure.Fabric.MSBuild.1.6.6\build\Microsoft.VisualStudio.Azure.Fabric.Application.props')" />
   <PropertyGroup Label="Globals">
     <ProjectGuid>a412c9fe-dd03-40d8-80f7-f9806a083140</ProjectGuid>
-    <ProjectVersion>1.6</ProjectVersion>
+    <ProjectVersion>2.1</ProjectVersion>
     <MinToolsVersion>1.5</MinToolsVersion>
+    <SupportedMSBuildNuGetPackageVersion>1.6.6</SupportedMSBuildNuGetPackageVersion>
   </PropertyGroup>
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|x64">
@@ -38,9 +39,9 @@
     <ApplicationProjectTargetsPath>$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\Service Fabric Tools\Microsoft.VisualStudio.Azure.Fabric.ApplicationProject.targets</ApplicationProjectTargetsPath>
   </PropertyGroup>
   <Import Project="$(ApplicationProjectTargetsPath)" Condition="Exists('$(ApplicationProjectTargetsPath)')" />
-  <Import Project="..\packages\Microsoft.VisualStudio.Azure.Fabric.MSBuild.1.6.3\build\Microsoft.VisualStudio.Azure.Fabric.Application.targets" Condition="Exists('..\packages\Microsoft.VisualStudio.Azure.Fabric.MSBuild.1.6.3\build\Microsoft.VisualStudio.Azure.Fabric.Application.targets')" />
+  <Import Project="..\packages\Microsoft.VisualStudio.Azure.Fabric.MSBuild.1.6.6\build\Microsoft.VisualStudio.Azure.Fabric.Application.targets" Condition="Exists('..\packages\Microsoft.VisualStudio.Azure.Fabric.MSBuild.1.6.6\build\Microsoft.VisualStudio.Azure.Fabric.Application.targets')" />
   <Target Name="ValidateMSBuildFiles">
-    <Error Condition="!Exists('..\packages\Microsoft.VisualStudio.Azure.Fabric.MSBuild.1.6.3\build\Microsoft.VisualStudio.Azure.Fabric.Application.props')" Text="Unable to find the '..\packages\Microsoft.VisualStudio.Azure.Fabric.MSBuild.1.6.3\build\Microsoft.VisualStudio.Azure.Fabric.Application.props' file. Please restore the 'Microsoft.VisualStudio.Azure.Fabric.MSBuild' Nuget package." />
-    <Error Condition="!Exists('..\packages\Microsoft.VisualStudio.Azure.Fabric.MSBuild.1.6.3\build\Microsoft.VisualStudio.Azure.Fabric.Application.targets')" Text="Unable to find the '..\packages\Microsoft.VisualStudio.Azure.Fabric.MSBuild.1.6.3\build\Microsoft.VisualStudio.Azure.Fabric.Application.targets' file. Please restore the 'Microsoft.VisualStudio.Azure.Fabric.MSBuild' Nuget package." />
+    <Error Condition="!Exists('..\packages\Microsoft.VisualStudio.Azure.Fabric.MSBuild.1.6.6\build\Microsoft.VisualStudio.Azure.Fabric.Application.props')" Text="Unable to find the '..\packages\Microsoft.VisualStudio.Azure.Fabric.MSBuild.1.6.6\build\Microsoft.VisualStudio.Azure.Fabric.Application.props' file. Please restore the 'Microsoft.VisualStudio.Azure.Fabric.MSBuild' Nuget package." />
+    <Error Condition="!Exists('..\packages\Microsoft.VisualStudio.Azure.Fabric.MSBuild.1.6.6\build\Microsoft.VisualStudio.Azure.Fabric.Application.targets')" Text="Unable to find the '..\packages\Microsoft.VisualStudio.Azure.Fabric.MSBuild.1.6.6\build\Microsoft.VisualStudio.Azure.Fabric.Application.targets' file. Please restore the 'Microsoft.VisualStudio.Azure.Fabric.MSBuild' Nuget package." />
   </Target>
 </Project>

--- a/ServiceFabric.DataProtection/packages.config
+++ b/ServiceFabric.DataProtection/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.VisualStudio.Azure.Fabric.MSBuild" version="1.6.3" />
+  <package id="Microsoft.VisualStudio.Azure.Fabric.MSBuild" version="1.6.6" />
 </packages>


### PR DESCRIPTION
Upgrade Service Fabric SDK to 6.2.283 / 3.1.283
Microsoft.AspNetCore Upgrade(s)
DataProtectionService Uri must be supplied via PersistKeysToServiceFabric etc